### PR TITLE
When the header of SUMMARY.md has special characters (such as "." or

### DIFF
--- a/cli/udocs/docs.go
+++ b/cli/udocs/docs.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/UltimateSoftware/udocs/cli/storage"
@@ -203,7 +204,9 @@ func ExtractRoute(r io.Reader) string {
 			sb.WriteRune('-')
 		}
 	}
-	return strings.Replace(sb.String(), "/", "-", -1)
+	alphanum := regexp.MustCompile("[^a-z0-9]+")
+	clean := regexp.MustCompile("^-+|-+$")
+	return clean.ReplaceAllString(alphanum.ReplaceAllString(sb.String(), "-"), "")
 }
 
 func UpdateSearchIndex(summary Summary, dao storage.Dao) error {

--- a/cli/udocs/docs_test.go
+++ b/cli/udocs/docs_test.go
@@ -44,16 +44,17 @@ func TestBuild(t *testing.T) {
 }
 
 const testSummary = `
-# My Test 	Route/Path
+# My Test 1.0 	(Route/Path)
 * [Overview](README.md)
 * [Tests](tests/README.md)
 	* [Unit](test/unit.md)
 `
 
 func TestExtractRoute(t *testing.T) {
+	expected := "my-test-1-0-route-path"
 	summary := bytes.NewReader([]byte(testSummary))
 	route := ExtractRoute(summary)
-	if route != "my-test-route-path" {
-		t.Errorf("Expected: my-test-route, Got: %s", route)
+	if route != expected {
+		t.Errorf("Expected: %s, Got: %s", expected, route)
 	}
 }


### PR DESCRIPTION
"?"), rendering the root route would fail with a 404. This change
converts all consecutive non-alphanumeric characters into a single
hyphen ("-") in the URI, and does trims any starting or ending hyphens
off.

Thus, a SUMMARY.md header that looks like:

 `# Summary 1.2 (Test)`

 Will be translated into a URI that looks like:

  `/summary-1-2-test`